### PR TITLE
Fix rails 5.1 compatibility issues

### DIFF
--- a/lib/songkick/oauth2/model/client.rb
+++ b/lib/songkick/oauth2/model/client.rb
@@ -5,7 +5,7 @@ module Songkick
       class Client < ActiveRecord::Base
         self.table_name = :oauth2_clients
 
-        belongs_to :oauth2_client_owner, :polymorphic => true
+        belongs_to :oauth2_client_owner, :polymorphic => true, optional: true
         alias :owner  :oauth2_client_owner
         alias :owner= :oauth2_client_owner=
 
@@ -56,4 +56,3 @@ module Songkick
     end
   end
 end
-

--- a/lib/songkick/oauth2/schema/20120828112156_songkick_oauth2_schema_original_schema.rb
+++ b/lib/songkick/oauth2/schema/20120828112156_songkick_oauth2_schema_original_schema.rb
@@ -1,4 +1,4 @@
-class SongkickOauth2SchemaOriginalSchema < ActiveRecord::Migration
+class SongkickOauth2SchemaOriginalSchema < ActiveRecord::Migration[4.2]
   def self.up
     create_table :oauth2_clients do |t|
       t.timestamps
@@ -33,4 +33,3 @@ class SongkickOauth2SchemaOriginalSchema < ActiveRecord::Migration
     drop_table :oauth2_authorizations
   end
 end
-

--- a/lib/songkick/oauth2/schema/20121024180930_songkick_oauth2_schema_add_authorization_index.rb
+++ b/lib/songkick/oauth2/schema/20121024180930_songkick_oauth2_schema_add_authorization_index.rb
@@ -1,4 +1,4 @@
-class SongkickOauth2SchemaAddAuthorizationIndex < ActiveRecord::Migration
+class SongkickOauth2SchemaAddAuthorizationIndex < ActiveRecord::Migration[4.2]
   INDEX_NAME = 'index_owner_client_pairs'
 
   def self.up
@@ -11,4 +11,3 @@ class SongkickOauth2SchemaAddAuthorizationIndex < ActiveRecord::Migration
     add_index :oauth2_authorizations, [:client_id, :access_token_hash]
   end
 end
-

--- a/lib/songkick/oauth2/schema/20121025180447_songkick_oauth2_schema_add_unique_indexes.rb
+++ b/lib/songkick/oauth2/schema/20121025180447_songkick_oauth2_schema_add_unique_indexes.rb
@@ -1,4 +1,4 @@
-class SongkickOauth2SchemaAddUniqueIndexes < ActiveRecord::Migration
+class SongkickOauth2SchemaAddUniqueIndexes < ActiveRecord::Migration[4.2]
   FIELDS = [:code, :refresh_token_hash]
 
   def self.up
@@ -35,4 +35,3 @@ class SongkickOauth2SchemaAddUniqueIndexes < ActiveRecord::Migration
     remove_index :oauth2_clients, [:name]
   end
 end
-


### PR DESCRIPTION
Rails 5.1+ does not support inheriting directly from `ActiveRecord::Migration`. Instead, the version of ActiveRecord at which the migration was generated must be specified.

Rails 5 also expects a `belongs_to` to be mandatory. This PR sets owner as optional to keep the behaviour as it was with rails 4.